### PR TITLE
- payment title color in light mode was fixed

### DIFF
--- a/app/src/main/java/com/exercise/testcompose/presentation/ui/screen/PaymentScreen.kt
+++ b/app/src/main/java/com/exercise/testcompose/presentation/ui/screen/PaymentScreen.kt
@@ -38,7 +38,7 @@ fun PaymentScreen(navController: NavController, viewModel: PaymentViewModel = hi
 
         Text(
             text = stringResource(R.string.payment),
-            style = MaterialTheme.typography.h4,
+            style = MaterialTheme.typography.h4.copy(color = MaterialTheme.colors.surface),
             modifier = Modifier.padding(bottom = 20.dp)
         )
 


### PR DESCRIPTION
Payment screen title color in light mode was fixed.

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/26595762/156888526-6e6714b5-fcdf-42e6-b2e4-49589360bed3.png" alt="Screenshot_20220305_145217" width=260>  | <img src="https://user-images.githubusercontent.com/26595762/156888576-2d2d3e05-9e9c-4555-b414-a73737729fff.png" alt="Screenshot_20220305_145139" width=260>  |
